### PR TITLE
fix: performance improvement

### DIFF
--- a/src/components/TrackRow.tsx
+++ b/src/components/TrackRow.tsx
@@ -81,6 +81,8 @@ const TrackRow = ({ track, handleClickEdit, handleClickSelect }: TrackRowProps) 
             src={track.coverImage || DEFAULT_IMAGE_COVER}
             alt={`${track.title} cover`}
             className="w-full h-full object-cover"
+            loading="lazy"
+            decoding="async"
           />
         </div>
 

--- a/src/interfaces/TracksFilterOptions.ts
+++ b/src/interfaces/TracksFilterOptions.ts
@@ -7,7 +7,7 @@ export const searchParamsSchema = z.object({
   sort: z.enum(['title', 'artist', 'album', 'createdAt']).default('title'),
   order: z.enum(['asc', 'desc']).default('asc'),
   page: z.number().default(1),
-  limit: z.number().default(10),
+  limit: z.number().default(5),
 });
 
 export type TracksFilterOptions = z.infer<typeof searchParamsSchema>;


### PR DESCRIPTION
Locally these updates got me from 92 to 94 in the lighthouse. 

Now some of my takes on this task:
- Lots of things can be managed better on the backend side. SQL DD with indexes (There is currently  no db on the backend lol)
- Preferably using a CDN like `Cloudinary` that automatically optimises images. 
- Critical CSS seemed like overkill. I really didn't want to extract a lot of Tailwind styles and then inline them for the track route.
- Maybe there is a way to avoid a redirect from `/index` to `/tracks`.
- Database queries typically take most of the time. Normally, you start there.

I tested the production version locally in a clean virtual environment on the latest Chrome version (138.0.7204.93). In the real world, the apps are tested on a clean remote machine.
Additionally, I hate premature optimisation. I support the wider idea of optimising only when it's absolutely needed.